### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": "~1.21.1",
+		"minecraft": ">=1.19.2 <1.21.2",
 		"java": ">=21",
 		"fabric-api": "*",
 		"fabric-language-kotlin": "*"


### PR DESCRIPTION
i saw on modrinth you set 1.19.2, 1.20.1, 1.21.1 as supported versions, however fabric.mod.json says the contrary